### PR TITLE
Fix duplicated "bitwise AND" when it should be "bitwise OR".

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Non-register arguments follow any register arguments in words as they are, in or
 |`0x00E`|`[ICPY]`|2|No|Moves the first argument as an immediate value into the second argument location.|Sets `FZERO` if the value is 0. Ignores `AFLG0`.|
 |`0x00F`|`[CMP]`|2|No|Compares the first argument to the second.|Sets `FZERO` if either argument is 0. Sets `FEQUL` if the two arguments are equal. Sets `FLT` or `FGT` if the first argument is less or greater respectively than the second.|
 |`0x010`|`[AND]`|2|No|Bitwise ANDs the first argument in place with the second.|Sets `FZERO` if the result is 0.|
-|`0x011`|`[OR]`|2|No|Bitwise ANDs the first argument in place with the second.|Sets `FZERO` if the result is 0.|
+|`0x011`|`[OR]`|2|No|Bitwise ORs the first argument in place with the second.|Sets `FZERO` if the result is 0.|
 |`0x012`|`[CMPL]`|1|No|Replaces the argument with its bitwise complement.|Sets `FZERO` if the result is 0.|
 |`0x013`|`[LSHF]`|2|No|Shifts the first argument left by the second argument's number of bits.|Sets `FZERO` if the result is 0. Fills bits on the right with 0.|
 |`0x014`|`[RSHF]`|2|Yes|Shifts the first argument right by the second argument's number of bits.|Sets `FZERO` if the result is 0. Fills bits on the left with 0 if `SIGN` is `0`, and the leftmost bit of the original value if `SIGN` is `1`.|

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Non-register arguments follow any register arguments in words as they are, in or
 |`0x040`|`[XOR]`|2|No|Bitwise XORs the first argument in place with the second.|Sets `FZERO` if the result is 0.|
 |`0x041`|`[SWAP]`|2|No|Swaps the first and second arguments.|Sets `FZERO` if either argument is 0.|
 |`0x042`|`[RCPT]`|2|Yes|Copies the first argument to the second argument offset forwards (if `SIGN` is set) or backwards (if not) by `RTRGT`.|The second argument must be a memory space address. Sets `FZERO` if the value is 0. Overflow is resolved by wrapping.|
-|`0x043`|`[RCPF]`|2|Yes|Copies the first argument offset forwards (if `SIGN` is set) or backwards (if not) by `RTRGT` to the second argument.|The first argument must be a memory space address. Sets `FZERO` if the value is 0. Overflow is resolved by wrapping.|
+|`0x043`|`[RCPF]`|2|Yes|Copies the second argument offset forwards (if `SIGN` is set) or backwards (if not) by `RTRGT` to the first argument.|The first argument must be a memory space address. Sets `FZERO` if the value is 0. Overflow is resolved by wrapping.|
 
 Any unrecognized opcode or violation of a requirement for arguments specified in an opcode's notes causes execution to halt.
 


### PR DESCRIPTION
Title, the instruction description for `OR` is slightly wrong.